### PR TITLE
Update RegEx to parse more URLs

### DIFF
--- a/lib/conred/video.rb
+++ b/lib/conred/video.rb
@@ -57,8 +57,8 @@ module Conred
       if @video_url[/youtu\.be\/([^\?]*)/]
           youtube_id = $1
       else
-        @video_url[/^.*((v\/)|(embed\/)|(watch\?))\??v?=?([^\&\?]*).*/]
-        youtube_id = $5
+        @video_url[/(v=([A-Za-z0-9_]*))/]
+        youtube_id = $2
       end
       <<-eos
       <iframe

--- a/spec/conred_spec/video_spec.rb
+++ b/spec/conred_spec/video_spec.rb
@@ -49,9 +49,10 @@ describe Conred do
       Conred::Video.new("eeevil vimeo www.vimeo.com/12311233").youtube_video? == false
     end  
     it "should return correct embed code" do
-       Conred::Video.new("http://www.youtube.com/watch?v=Lrj5Kxdzouc", 450, 300).code.should == @youtube_embed_code
-       Conred::Video.new("http://vimeo.com/49556689", 450, 300).code.should == @vimeo_embed_code
-       Conred::Video.new("http://google.com/12311233", 450, 300, "Some mistake in url").code.should == "Some mistake in url"
+      Conred::Video.new("http://www.youtube.com/watch?NR=1&feature=endscreen&v=Lrj5Kxdzouc", 450, 300).code.should == @youtube_embed_code
+      Conred::Video.new("http://www.youtube.com/watch?v=Lrj5Kxdzouc", 450, 300).code.should == @youtube_embed_code
+      Conred::Video.new("http://vimeo.com/49556689", 450, 300).code.should == @vimeo_embed_code
+      Conred::Video.new("http://google.com/12311233", 450, 300, "Some mistake in url").code.should == "Some mistake in url"
     end
   end
 end


### PR DESCRIPTION
There was a URL listed in issue #1 in which the original RegEx failed to match the video id.  I updated the tests and then fixed the RegExp.  Closes #1
