### PR TITLE
Removing duplication + a lot of changes

### DIFF
--- a/lib/conred.rb
+++ b/lib/conred.rb
@@ -5,5 +5,13 @@ require "conred/video"
 require "conred/links"
 require "haml"
 module Conred
-
+  def Video.new arguments
+    if Video::Youtube.url_format_is_valid? arguments[:video_url]
+      Video::Youtube.new arguments
+    elsif Video::Vimeo.url_format_is_valid? arguments[:video_url]
+      Video::Vimeo.new arguments
+    else
+      Video::Other.new arguments
+    end
+  end
 end

--- a/lib/conred/video.rb
+++ b/lib/conred/video.rb
@@ -26,6 +26,13 @@ module Conred
       ).html_safe
     end
 
+    def exist?
+      response = Net::HTTP.get_response(URI(api_uri))
+      response.is_a?(Net::HTTPSuccess)
+    end
+
+    private
+
     def render(locals = {})
       path = File.join(
         File.dirname(__FILE__),
@@ -41,9 +48,8 @@ module Conred
         /^(http:\/\/)*(www\.)*(youtube.com|youtu.be)/ =~ url
       end
 
-      def exist?
-        response = Net::HTTP.get_response(URI("http://gdata.youtube.com/feeds/api/videos/#{@video_id}"))
-        response.is_a?(Net::HTTPSuccess)
+      def api_uri
+        "http://gdata.youtube.com/feeds/api/videos/#{@video_id}"
       end
 
       def video_link
@@ -69,9 +75,8 @@ module Conred
         /^(http:\/\/)*(www\.)*(vimeo.com)/ =~ url
       end
 
-      def exist?
-        response = Net::HTTP.get_response(URI("http://vimeo.com/api/v2/video/#{@video_id}.json"))
-        response.is_a?(Net::HTTPSuccess)
+      def api_uri
+        "http://vimeo.com/api/v2/video/#{@video_id}.json"
       end
 
       def video_link

--- a/lib/conred/video.rb
+++ b/lib/conred/video.rb
@@ -21,13 +21,12 @@ module Conred
     end
 
     def youtube_video?
-      /^(http:\/\/)*(www\.)*(youtube.com|youtu.be)/ =~ @video_url ? true : false
+      /^(http:\/\/)*(www\.)*(youtube.com|youtu.be)/ =~ @video_url
     end
 
     def vimeo_video?
-      /^(http:\/\/)*(www\.)*(vimeo.com)/ =~ @video_url ? true : false
+      /^(http:\/\/)*(www\.)*(vimeo.com)/ =~ @video_url
     end
-
 
     def video_from_vimeo_url
       vimeo_partial = "../views/video/vimeo_iframe"

--- a/lib/conred/video.rb
+++ b/lib/conred/video.rb
@@ -3,11 +3,11 @@ require "action_view"
 require "net/http"
 module Conred
   class Video
-    def initialize(video_url, width = 670, height = 450, error_message = "Video url you have provided is invalid")
-      @width = width
-      @height = height
-      @video_url = video_url
-      @error_message = error_message
+    def initialize(arguments = {:width => 670, :height => 450, :error_message => "Video url you have provided is invalid"})
+      @width = arguments[:width]
+      @height = arguments[:height]
+      @video_url = arguments[:video_url]
+      @error_message = arguments[:error_message]
     end
 
     def code
@@ -75,6 +75,5 @@ module Conred
       end
       response.is_a?(Net::HTTPSuccess)
     end
-
   end
 end

--- a/lib/conred/video.rb
+++ b/lib/conred/video.rb
@@ -37,6 +37,10 @@ module Conred
     class Youtube
       include Video
 
+      def self.url_format_is_valid? url
+        /^(http:\/\/)*(www\.)*(youtube.com|youtu.be)/ =~ url
+      end
+
       def exist?
         response = Net::HTTP.get_response(URI("http://gdata.youtube.com/feeds/api/videos/#{@video_id}"))
         response.is_a?(Net::HTTPSuccess)
@@ -60,6 +64,10 @@ module Conred
 
     class Vimeo
       include Video
+
+      def self.url_format_is_valid? url
+        /^(http:\/\/)*(www\.)*(vimeo.com)/ =~ url
+      end
 
       def exist?
         response = Net::HTTP.get_response(URI("http://vimeo.com/api/v2/video/#{@video_id}.json"))
@@ -89,24 +97,4 @@ module Conred
       end
     end
   end
-
-
-  def Video.new arguments
-    if Conred.youtube_video? arguments[:video_url]
-      Video::Youtube.new arguments
-    elsif Conred.vimeo_video? arguments[:video_url]
-      Video::Vimeo.new arguments
-    else
-      Video::Other.new arguments
-    end
-  end
-
-  def self.youtube_video? url
-    /^(http:\/\/)*(www\.)*(youtube.com|youtu.be)/ =~ url
-  end
-
-  def self.vimeo_video? url
-    /^(http:\/\/)*(www\.)*(vimeo.com)/ =~ url
-  end
-
 end

--- a/lib/views/video/video_iframe.html.haml
+++ b/lib/views/video/video_iframe.html.haml
@@ -1,0 +1,1 @@
+%iframe{:allowFullScreen => "", :frameborder => "0", :height => height, :mozallowfullscreen => "", :src => "#{video_link}", :webkitAllowFullScreen => "", :width => width}

--- a/lib/views/video/vimeo_iframe.html.haml
+++ b/lib/views/video/vimeo_iframe.html.haml
@@ -1,1 +1,0 @@
-%iframe{:allowFullScreen => "", :frameborder => "0", :height => height, :mozallowfullscreen => "", :src => "http://player.vimeo.com/video/#{vimeo_id}", :webkitAllowFullScreen => "", :width => width}

--- a/lib/views/video/youtube_iframe.html.haml
+++ b/lib/views/video/youtube_iframe.html.haml
@@ -1,1 +1,0 @@
-%iframe{:allowfullscreen => "", :frameborder => "0", :height => height, :src => "http://www.youtube.com/embed/#{youtube_id}?wmode=transparent", :title => "YouTube video player", :width => width}

--- a/spec/conred_spec/video_spec.rb
+++ b/spec/conred_spec/video_spec.rb
@@ -59,6 +59,11 @@ describe Conred do
         non_existing_video.exist?.should be_false
       end
 
+      it "should make a request to the proper uri" do
+        non_existing_video = Conred::Video.new(:video_url=>"http://www.youtube.com/watch?v=Lrj5Kxdzoux")
+        non_existing_video.api_uri.should eq("http://gdata.youtube.com/feeds/api/videos/Lrj5Kxdzoux")
+      end
+
       it "should be true if response is 200" do
         existing_video = Conred::Video.new(:video_url=>"http://www.youtube.com/watch?v=Lrj5Kxdzouc")
         Net::HTTP.stub(:get_response=>Net::HTTPOK.new(true,200,"OK"))

--- a/spec/conred_spec/video_spec.rb
+++ b/spec/conred_spec/video_spec.rb
@@ -3,14 +3,14 @@ require "conred"
 describe Conred do
   describe Conred::Video do
 
-    let(:short_youtube_url) {Conred::Video.new("http://youtu.be/SZt5RFzqEfY")}
-    let(:short_youtube_url_with_www) {Conred::Video.new("www.youtu.be/SZt5RFzqEfY")}
-    let(:long_youtube_url_with_features) {Conred::Video.new("http://www.youtube.com/watch?NR=1&feature=endscreen&v=Lrj5Kxdzouc")}
-    let(:short_youtube_url_without_http_and_www) {Conred::Video.new("youtu.be/SZt5RFzqEfY")}
+    let(:short_youtube_url) {Conred::Video.new(:video_url=>"http://youtu.be/SZt5RFzqEfY")}
+    let(:short_youtube_url_with_www) {Conred::Video.new(:video_url=>"www.youtu.be/SZt5RFzqEfY")}
+    let(:long_youtube_url_with_features) {Conred::Video.new(:video_url=>"http://www.youtube.com/watch?NR=1&feature=endscreen&v=Lrj5Kxdzouc")}
+    let(:short_youtube_url_without_http_and_www) {Conred::Video.new(:video_url=>"youtu.be/SZt5RFzqEfY")}
 
-    let(:vimeo_url) {Conred::Video.new("http://vimeo.com/12311233")}
-    let(:evil_vimeo) {Conred::Video.new("eeevil vimeo www.vimeo.com/12311233")}
-    let(:vimeo_without_http) {Conred::Video.new("vimeo.com/12311233")}
+    let(:vimeo_url) {Conred::Video.new(:video_url=>"http://vimeo.com/12311233")}
+    let(:evil_vimeo) {Conred::Video.new(:video_url=>"eeevil vimeo www.vimeo.com/12311233")}
+    let(:vimeo_without_http) {Conred::Video.new(:video_url=>"vimeo.com/12311233")}
     
     it "should match youtube video" do
       short_youtube_url.should be_youtube_video
@@ -30,26 +30,37 @@ describe Conred do
       vimeo_url.should be_vimeo_video
     end  
 
-    it "should return correct embed code" do
-      Conred::Video.new("http://www.youtube.com/watch?NR=1&feature=endscreen&v=Lrj5Kxdzouc", 450, 300).code.should match(/Lrj5Kxdzouc/)
-      Conred::Video.new("http://www.youtube.com/watch?v=Lrj5Kxdzouc", 450, 300).code.should match(/Lrj5Kxdzouc/)
-      Conred::Video.new("http://www.youtube.com/watch?v=Lrj5Kxdzouc", 450, 300).code.should match(/width='450'/)
-      Conred::Video.new("http://www.youtube.com/watch?v=Lrj5Kxdzouc", 450, 300).code.should match(/height='300'/)
-      Conred::Video.new("http://vimeo.com/49556689", 450, 300).code.should match(/49556689/)
-      Conred::Video.new("http://vimeo.com/49556689", 450, 300).code.should match(/width='450'/)
-      Conred::Video.new("http://vimeo.com/49556689", 450, 300).code.should match(/height='300'/)
-      Conred::Video.new("http://google.com/12311233", 450, 300, "Some mistake in url").code.should == "Some mistake in url"
+    describe "youtube embed code" do
+      subject {Conred::Video.new(:video_url=>"http://www.youtube.com/watch?v=Lrj5Kxdzouc", :width=>450,:height=> 300).code }
+      it { should match(/Lrj5Kxdzouc/)}
+      it { should match(/width='450'/)}
+      it {should match(/height='300'/)} 
+    end
+
+    describe "vimeo embed code" do
+      subject { Conred::Video.new(:video_url=>"http://vimeo.com/49556689", :width=>450, :height=>300).code }
+      it {should match(/49556689/)}
+      it {should match(/width='450'/)}
+      it {should match(/height='300'/)}
+    end
+
+    it "should render error message when url is invalid" do
+      Conred::Video.new(:video_url=>"http://google.com/12311233", :width=>450, :height=>300, :error_message=>"Some mistake in url").code.should == "Some mistake in url"
+    end
+
+    it "should return correct embed code when passing arguments in url" do
+      Conred::Video.new(:video_url=>"http://www.youtube.com/watch?NR=1&feature=endscreen&v=Lrj5Kxdzouc",:width=> 450,:height=> 300).code.should match(/Lrj5Kxdzouc/)
     end
 
     describe "check if a video exist" do
       it "should return false if request 404" do
-        non_existing_video = Conred::Video.new("http://www.youtube.com/watch?v=Lrj5Kxdzoux")
+        non_existing_video = Conred::Video.new(:video_url=>"http://www.youtube.com/watch?v=Lrj5Kxdzoux")
         Net::HTTP.stub(:get_response=>Net::HTTPNotFound.new(true, 404, "Not Found"))
         non_existing_video.exist?.should be_false
       end
 
       it "should be true if response is 200" do
-        existing_video = Conred::Video.new("http://www.youtube.com/watch?v=Lrj5Kxdzouc")
+        existing_video = Conred::Video.new(:video_url=>"http://www.youtube.com/watch?v=Lrj5Kxdzouc")
         Net::HTTP.stub(:get_response=>Net::HTTPOK.new(true,200,"OK"))
         existing_video.exist?.should be_true
       end


### PR DESCRIPTION
Hi,
this is quite a lot of changes. The fact that youtube and vimeo videos where the same Video Object behaving differently was smelly and introducing a lot of duplication.
Both youtube and vimeo are now have there own class.

We can still create a new video with the command `Conred::Video.new`

I think the code is cleaner and it would now be easier to add a new "type" of video.

Tell me what you think about it.
