### PR TITLE
Restore Video#exist? method

### DIFF
--- a/lib/conred/video.rb
+++ b/lib/conred/video.rb
@@ -37,7 +37,7 @@ module Conred
     end
 
     def exist?
-      response = Net::HTTP.get_response(URI(api_uri))
+      response = Net::HTTP.get_response(URI("https:#{api_uri}"))
       response.is_a?(Net::HTTPSuccess)
     end
 

--- a/spec/conred_spec/video_spec.rb
+++ b/spec/conred_spec/video_spec.rb
@@ -64,7 +64,6 @@ describe Conred do
     describe "check if a video exist" do
       it "should return false if request 404" do
         non_existing_video = Conred::Video.new(:video_url=>"http://www.youtube.com/watch?v=Lrj5Kxdzoux")
-        Net::HTTP.stub(:get_response=>Net::HTTPNotFound.new(true, 404, "Not Found"))
         non_existing_video.exist?.should be_false
       end
 
@@ -75,7 +74,6 @@ describe Conred do
 
       it "should be true if response is 200" do
         existing_video = Conred::Video.new(:video_url=>"http://www.youtube.com/watch?v=Lrj5Kxdzouc")
-        Net::HTTP.stub(:get_response=>Net::HTTPOK.new(true,200,"OK"))
         existing_video.exist?.should be_true
       end
 


### PR DESCRIPTION
This method was failing due to `api_uri` being parsed as a generic URI which caused problems when passed to `Net::HTTP.get_response`. The specs were using stubs so they didn't catch the problem.

We could probably add VCR to ensure these specs stay green even if the test YouTube videos are removed. It's a bit heavy handed so I left it out for now. 
