### PR TITLE
unit-tested proper vimeo uri request

### DIFF
--- a/spec/conred_spec/video_spec.rb
+++ b/spec/conred_spec/video_spec.rb
@@ -67,13 +67,18 @@ describe Conred do
 
     describe "check if a video exist" do
       it "should return false if request 404" do
-        non_existing_video = Conred::Video.new(:video_url=>"http://www.youtube.com/watch?v=Lrj5Kxdzoux")
+          non_existing_video = Conred::Video.new(:video_url=>"http://www.youtube.com/watch?v=Lrj5Kxdzoux")
         expect(non_existing_video.exist?).to eq(false)
       end
 
-      it "should make a request to the proper uri" do
-        non_existing_video = Conred::Video.new(:video_url=>"http://www.youtube.com/watch?v=Lrj5Kxdzoux")
-        expect(non_existing_video.api_uri).to eq("//gdata.youtube.com/feeds/api/videos/Lrj5Kxdzoux")
+      it "should make a request to the proper youtube uri" do
+        non_existing_youtube_video = Conred::Video.new(:video_url=>"http://www.youtube.com/watch?v=Lrj5Kxdzoux")
+        expect(non_existing_youtube_video.api_uri).to eq("//gdata.youtube.com/feeds/api/videos/Lrj5Kxdzoux")
+      end
+
+      it "should make a request to the proper vimeo uri" do
+        non_existing_vimeo_video = Conred::Video.new(:video_url=>"http://vimeo.com/49556689")
+        expect(non_existing_vimeo_video.api_uri).to eq("//vimeo.com/api/v2/video/49556689.json")
       end
 
       it "should be true if response is 200" do


### PR DESCRIPTION
Hi,
I have noticed that your test cases were not covering the VimeoStrategy#api_uri so I wrote a test for that.
Also, you might want to have a look at the naming of your test methods. Some don't really communicate the intent, e.g.; "should be true if response is 200" could be more like "when a video exists response is  200" (with the first part in the describe)
