### PR TITLE
Refactor the strategy local variable

### DIFF
--- a/lib/conred/video.rb
+++ b/lib/conred/video.rb
@@ -16,8 +16,8 @@ module Conred
 
     def self.new(arguments)
       available_strategies = [YoutubeStrategy,Video::VimeoStrategy,Video::OtherStrategy]
-      strategy = available_strategies.select { |strategy| strategy.url_format_is_valid?(arguments[:video_url])}.first
-      strategy.new arguments
+      selected_strategy = available_strategies.select { |strategy| strategy.url_format_is_valid?(arguments[:video_url])}.first
+      selected_strategy.new arguments
     end
 
     def youtube_video?


### PR DESCRIPTION
The inner variable in the `select` is shadowing the local variable and that could be confusing if this code were to expand. The local variable is now named `selected_strategy` to make this truly distinct.
