### PR TITLE
View count feature for vimeo and youtube videos added.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ Or if it exists:
 c.exists? # => true
 ```
 
+You can also obtain the view count of the video like this:
+
+```ruby
+c.viewCount
+```
+
 ## Contributing
 
 1. Fork it

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ c.exists? # => true
 You can also obtain the view count of the video like this:
 
 ```ruby
-c.viewCount
+c.view_count
 ```
 
 ## Contributing

--- a/conred.gemspec
+++ b/conred.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency "rspec", '~> 2.0'
   gem.add_development_dependency "rake", '~> 10.1'
   gem.add_development_dependency "pry"
+  gem.add_development_dependency "activesupport"
 
   gem.files         = `git ls-files`.split($\)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }

--- a/lib/conred/video.rb
+++ b/lib/conred/video.rb
@@ -42,22 +42,21 @@ module Conred
       response.is_a?(Net::HTTPSuccess)
     end
 
-    def viewCount
-      if self.exist?
-        body = Net::HTTP.get_response(URI("http:#{api_uri}")).body
-
-        if self.youtube_video?
+    def view_count
+      return nil unless exist? == true
+      Net::HTTP.get_response(URI("http:#{api_uri}")).body.tap do |body|
+        if youtube_video?
           body_json = Hash.from_xml(body).to_json
           body_hash = JSON.parse(body_json)
-          viewCount = body_hash["entry"]["statistics"]["viewCount"]
-        end
-
-        if self.vimeo_video?
+          #returning view_count by parsing the Youtube API response
+          return (body_hash["entry"]["statistics"]["viewCount"]).to_i 
+        elsif vimeo_video?
           body_hash = JSON.parse(body)
-          viewCount = body_hash.first['stats_number_of_plays']
+          #returning view_count by parsing the Vimeo API response
+          return (body_hash.first['stats_number_of_plays']).to_i
+        else
+          return nil
         end
-
-        return viewCount.to_i unless viewCount.nil?
       end
     end
 

--- a/lib/conred/video.rb
+++ b/lib/conred/video.rb
@@ -43,7 +43,7 @@ module Conred
     end
 
     def viewCount
-      if self.exist?
+      if self.exists?
         body = get_api_response.body
 
         if self.youtube_video?

--- a/lib/conred/video.rb
+++ b/lib/conred/video.rb
@@ -38,11 +38,34 @@ module Conred
     end
 
     def exist?
-      response = Net::HTTP.get_response(URI("http:#{api_uri}"))
+      response = get_api_response
       response.is_a?(Net::HTTPSuccess)
+    end
+
+    def viewCount
+      if self.exist?
+        body = get_api_response.body
+
+        if self.youtube_video?
+          body_json = Hash.from_xml(response.body).to_json
+          body_hash = JSON.parse(body_json)
+          body_hash["entry"]["statistics"]["viewCount"]
+        end
+
+        if self.vimeo_video?
+          body_hash = JSON.parse(body)
+          body_hash['stats_number_of_plays']
+        end
+      end
     end
 
     attr_reader :height, :width, :video_id, :error_message
 
+  end
+
+  private 
+
+  def get_api_response
+    Net::HTTP.get_response(URI("http:#{api_uri}"))
   end
 end

--- a/spec/conred_spec/video_spec.rb
+++ b/spec/conred_spec/video_spec.rb
@@ -15,13 +15,13 @@ describe Conred do
     let(:vimeo_without_http) {Conred::Video.new(:video_url=>"vimeo.com/12311233")}
 
     let(:error_video) { Conred::Video.new(
-      :video_url => "http://google.com/12311233",
-      :error_message => "Some mistake in url")
-    }
+                          :video_url => "http://google.com/12311233",
+                        :error_message => "Some mistake in url")
+                        }
 
     it "should match youtube video" do
       expect(short_youtube_url).to be_youtube_video
-      expect(https_youtube_url).to be_youtube_video 
+      expect(https_youtube_url).to be_youtube_video
       expect(short_youtube_url_with_www).to be_youtube_video
       expect(long_youtube_url_with_features).to be_youtube_video
       expect(short_youtube_url_without_http_and_www).to be_youtube_video
@@ -83,6 +83,30 @@ describe Conred do
 
       it "should be false if uri isn't recognized" do
         expect(error_video.exist?).to eq(false)
+      end
+    end
+
+    describe "view count check" do
+      it "should render the view count of an existing youtube video" do
+        existing_video = Conred::Video.new(:video_url=>"http://www.youtube.com/watch?v=Lrj5Kxdzouc")
+        expect(existing_video.viewCount.is_a? Integer).to eq(true)
+        expect(existing_video.viewCount).to be > 2000000
+      end
+
+      it "should return nil for the view count for a non existing youtube video" do
+        non_existing_video = Conred::Video.new(:video_url=>"http://www.youtube.com/watch?v=Lrj5Kxdzoux")
+        expect(non_existing_video.viewCount).to eq(nil)
+      end
+
+      it "should render the view count of an existing vimeo video" do
+        existing_video = Conred::Video.new(:video_url=>"http://vimeo.com/87701971")
+        expect(existing_video.viewCount.is_a? Integer).to eq(true)
+        expect(existing_video.viewCount).to be > 1900000
+      end
+
+      it "should return nil for the view count for a non existing vimeo video" do
+        non_existing_video = Conred::Video.new(:video_url=>"http://vimeo.com/877019718976876")
+        expect(non_existing_video.viewCount).to eq(nil)
       end
     end
   end

--- a/spec/conred_spec/video_spec.rb
+++ b/spec/conred_spec/video_spec.rb
@@ -89,24 +89,24 @@ describe Conred do
     describe "view count check" do
       it "should render the view count of an existing youtube video" do
         existing_video = Conred::Video.new(:video_url=>"http://www.youtube.com/watch?v=Lrj5Kxdzouc")
-        expect(existing_video.viewCount.is_a? Integer).to eq(true)
-        expect(existing_video.viewCount).to be > 2000000
+        expect(existing_video.view_count.is_a? Integer).to eq(true)
+        expect(existing_video.view_count).to be > 2000000
       end
 
       it "should return nil for the view count for a non existing youtube video" do
         non_existing_video = Conred::Video.new(:video_url=>"http://www.youtube.com/watch?v=Lrj5Kxdzoux")
-        expect(non_existing_video.viewCount).to eq(nil)
+        expect(non_existing_video.view_count).to eq(nil)
       end
 
       it "should render the view count of an existing vimeo video" do
         existing_video = Conred::Video.new(:video_url=>"http://vimeo.com/87701971")
-        expect(existing_video.viewCount.is_a? Integer).to eq(true)
-        expect(existing_video.viewCount).to be > 1900000
+        expect(existing_video.view_count.is_a? Integer).to eq(true)
+        expect(existing_video.view_count).to be > 1900000
       end
 
       it "should return nil for the view count for a non existing vimeo video" do
         non_existing_video = Conred::Video.new(:video_url=>"http://vimeo.com/877019718976876")
-        expect(non_existing_video.viewCount).to eq(nil)
+        expect(non_existing_video.view_count).to eq(nil)
       end
     end
   end


### PR DESCRIPTION
I have added a feature to obtain the view count of the youtube and the vimeo videos. The user can use this feature in many ways such as to embed a video only if the view count is greater than a certain number etc. if the video doesn't exist, nil is returned otherwise the number is returned as an integer. I have also added the Rspec tests for it.
