### PR TITLE
Add support for vimeo channel urls

### DIFF
--- a/lib/conred/generator_strategies/vimeo_strategy.rb
+++ b/lib/conred/generator_strategies/vimeo_strategy.rb
@@ -16,7 +16,7 @@ class Conred::Video::VimeoStrategy
   private
 
   def get_video_id_from url
-    url[/vimeo\.com\/([0-9]*)/]
-    @video_id = $1
+    url[/vimeo\.com\/((\w*\/)+)?([0-9]*)/]
+    @video_id = $3
   end
 end

--- a/lib/conred/generator_strategies/youtube_strategy.rb
+++ b/lib/conred/generator_strategies/youtube_strategy.rb
@@ -6,7 +6,7 @@ class Conred::Video::YoutubeStrategy
   end
 
   def api_uri
-    "//gdata.youtube.com/feeds/api/videos/#{@video_id}"
+    "//www.youtube.com/oembed?format=json&url=https://www.youtube.com/watch?v=#{@video_id}"
   end
 
   def video_link

--- a/lib/views/video/video_iframe.html.erb
+++ b/lib/views/video/video_iframe.html.erb
@@ -1,2 +1,2 @@
-<iframe src="<%= video_link %>" frameborder="0" height="<%= height %>" width="<%= width %>" allowFullScreen mozallowfullscreen webkitAllowFullScreen >
+<iframe src="<%= video_link %>" frameborder="0" height="<%= height %>" width="<%= width %>" allowFullScreen >
 </iframe>

--- a/spec/conred_spec/video_spec.rb
+++ b/spec/conred_spec/video_spec.rb
@@ -11,6 +11,7 @@ describe Conred do
 
     let(:vimeo_url) {Conred::Video.new(:video_url=>"http://vimeo.com/12311233")}
     let(:https_vimeo_url) {Conred::Video.new(:video_url=>"http://vimeo.com/12311233")}
+    let(:vimeo_channel_url) {Conred::Video.new(:video_url=>"https://vimeo.com/channels/staffpicks/107469289")}
     let(:evil_vimeo) {Conred::Video.new(:video_url=>"eeevil vimeo www.vimeo.com/12311233")}
     let(:vimeo_without_http) {Conred::Video.new(:video_url=>"vimeo.com/12311233")}
 
@@ -37,6 +38,7 @@ describe Conred do
       expect(vimeo_without_http).to be_vimeo_video
       expect(https_vimeo_url).to be_vimeo_video
       expect(vimeo_url).to be_vimeo_video
+      expect(vimeo_channel_url).to be_vimeo_video
     end
 
     describe "youtube embed code" do

--- a/spec/conred_spec/video_spec.rb
+++ b/spec/conred_spec/video_spec.rb
@@ -75,7 +75,7 @@ describe Conred do
 
       it "should make a request to the proper youtube uri" do
         non_existing_youtube_video = Conred::Video.new(:video_url=>"http://www.youtube.com/watch?v=Lrj5Kxdzoux")
-        expect(non_existing_youtube_video.api_uri).to eq("//gdata.youtube.com/feeds/api/videos/Lrj5Kxdzoux")
+        expect(non_existing_youtube_video.api_uri).to eq("//www.youtube.com/oembed?format=json&url=https://www.youtube.com/watch?v=Lrj5Kxdzoux")
       end
 
       it "should make a request to the proper vimeo uri" do


### PR DESCRIPTION
Added support for vimeo channel url and fix youtube api_url for exist? method but unfortunately, due to api chnages I didn't manage to fix view counts cause one needs to have api key.